### PR TITLE
Bugfix: set remove_unnecessary_outputs to False to keep all xfmconcat outputs.

### DIFF
--- a/volgenmodel.py
+++ b/volgenmodel.py
@@ -730,6 +730,9 @@ def make_workflow():
 
         workflow.connect(preprocess_normalise, 'output_file', resample, 'input_file')
 
+        # Note: we don't explicitly use 'output_grids' from this node, so we
+        # have to set remove_unnecessary_outputs to False in the workflow object,
+        # otherwise Nipype will remove them and the resample nodes will fail.
         workflow.connect(xfmconcat, 'output_file',  resample, 'transformation')
 
         workflow.connect(voliso,               'output_file', resample, 'like')
@@ -869,6 +872,8 @@ def make_workflow():
 
 if __name__ == '__main__':
     workflow = make_workflow()
+    workflow.config['execution'] = {'remove_unnecessary_outputs': 'False'}
+
     workflow.run(plugin='Linear')
     # workflow.run(plugin='MultiProc', plugin_args={'n_procs' : 32})
     # workflow.run(plugin='PBSGraph',


### PR DESCRIPTION
@stebo85 reported:

> The problem seems to be that the output of xfmconcat is not tracked correctly and nipype complains about a missing grid_0.mnc file. The workflow folder only contains the xfm file and somehow the grid files are not there.

It looks like recent versions of Nipype will remove outputs that are not explicitly used in the workflow graph. One of the xfmconcat nodes is only connected downstream via its ``xfm`` file, not the ``grid`` files. As a simple workaround, setting ``remove_unnecessary_outputs`` to ``False`` keeps the grid files. 

A better fix would be to connect the output grid files to a dummy input.